### PR TITLE
Document existing .zshrc file rename when installing

### DIFF
--- a/Home.md
+++ b/Home.md
@@ -18,6 +18,8 @@
   | **curl**  | `sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"` |
   | **wget**  | `sh -c "$(wget -O- https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"`   |
   | **fetch** | `sh -c "$(fetch -o - https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"` |
+  
+  **WARNING - the above commands clobber your existing `.zshrc`! Don't paninc though, you will find your previous `.zshrc` has been saved as `.zshrc.pre-oh-my-zsh`**
 
 ## Getting started
 

--- a/Home.md
+++ b/Home.md
@@ -19,7 +19,7 @@
   | **wget**  | `sh -c "$(wget -O- https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"`   |
   | **fetch** | `sh -c "$(fetch -o - https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"` |
   
-  **WARNING - the above commands clobber your existing `.zshrc`! Don't paninc though, you will find your previous `.zshrc` has been saved as `.zshrc.pre-oh-my-zsh`**
+  **NOTE: the installer will rename an existing `.zshrc` file to `.zshrc.pre-oh-my-zsh`.**
 
 ## Getting started
 


### PR DESCRIPTION
Warn users of the imminent destruction of their existing .zshrc - and tell them how to deal with the surprise.