### PR TITLE
Update Oxide screenshot url

### DIFF
--- a/External-themes.md
+++ b/External-themes.md
@@ -417,7 +417,7 @@ Author: [@abaykan](https://github.com/abaykan)
 
 #### Oxide
 
-![oxide zsh](https://files.dikiaap.id/img/dotfiles/zsh.png)
+![oxide zsh](https://dikiaap.pages.dev/img/dotfiles/zsh.png)
 
 See [repository](https://github.com/dikiaap/dotfiles) for source.
 


### PR DESCRIPTION
The former url is inaccessible.