### PR TITLE
docs(Plugins-Overview.md): fix typo

### DIFF
--- a/Plugins-Overview.md
+++ b/Plugins-Overview.md
@@ -17,7 +17,7 @@
 
 | Name                                                                                                        | Description                                                                                                    |
 | ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
-| [ag](https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/ag)                                             | autocomplettion for ag                                                                                         |
+| [ag](https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/ag)                                             | autocompletion for ag                                                                                         |
 | [aliases](https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/aliases)                                   | aliases cheatsheet - list aliases based on the plugins that you have enabled                                   |
 | [autoenv](https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/autoenv)                                   | automatically execs script on changing dir (.env file)                                                         |
 | [colemak](https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/colemak)                                   | colemak layout support + vi-mode fixes for colemak https://en.wikipedia.org/wiki/Keyboard_layout#Colemak       |


### PR DESCRIPTION
`autocomplettion` -> `autocompletion`