### PR TITLE
Partial draft: add FAQ entry advising against OMZ as root

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -342,3 +342,13 @@ If you want this behavior to change, set the `WORDCHARS` variable in your zshrc 
 ```zsh
 WORDCHARS='_-*'
 ```
+
+## Why shouldn't I install Oh My Zsh as root?
+
+If something goes wrong with your config or Oh My Zsh, you risk breaking your system without a way to get back in, at least not without spinning up a live environment or doing a clean install. While this is rare, rare it's far more likely than with an OS stock config for the root user.
+
+In general, it's a good idea to leave the root user's config as untouched as possible, to help avoid error recovery and security problems. This includes leaving its shell as the system default (usually bash on Linux), and not installing Oh My Zsh for the root user.
+
+You _can_ still install Oh My Zsh for the root user, but it isn't a good idea.
+
+See also: [Why is it bad to log in as root?](https://askubuntu.com/a/16179/452364)


### PR DESCRIPTION
This question has come up on the Discord server twice in a relatively short amount of time, given traffic on there. This is a partial draft, because the entry is still a bit thin. Would be nice to expand it, but I'm not of ideas. It's also not sourced in a statement from OMZ devs, which would be nice to have alongside the general AU reference advising against root login. It would be nice to have a live comment in a relevant thread somewhere, if one exists, but if it doesn't, the FAQ entry can still stand on its own. 

Failed to find any good results for a dev statement; the closest I found is [this](https://github.com/ohmyzsh/ohmyzsh/issues/5311#issuecomment-240106715) from 2016, but it's just a statement that it's discouraged, and not really why. Searches for "root" are littered with loads of other stuff, but I'm guessing someone else might know where to look, or just have better luck with the search engine gods.