### PR TITLE
Update External-themes.md: links to zsh2000 theme

### DIFF
--- a/External-themes.md
+++ b/External-themes.md
@@ -371,13 +371,13 @@ Author: [@nikhilkmr300](https://github.com/nikhilkmr300)
 
 #### zsh2000
 
-![zsh2000 theme](https://raw.githubusercontent.com/maverick9000/zsh2000/master/demo.png)
+![zsh2000 theme](https://raw.githubusercontent.com/consolemaverick/zsh2000/master/demo.png)
 
 Powerline looking zsh theme with rvm prompt, git status and branch, current time, user, hostname, pwd, exit status, root and background job status.
 
 Influenced heavily by agnoster's theme and jeremyFreeAgent's theme
 
-Author: [@maverick9000](https://github.com/maverick9000)
+Author: [@consolemaverick](https://github.com/consolemaverick)
 
 #### Daivasmara
 


### PR DESCRIPTION
The old author link is dead. I updated the image link as well.