### PR TITLE
fix(_Sidebar): broken stickers link

### DIFF
--- a/_Sidebar.md
+++ b/_Sidebar.md
@@ -29,7 +29,7 @@
 <p align="center"><a href="https://shop.planetargon.com/products/ohmyzsh-t-shirts"><img width="100%" alt="Black Oh My Zsh t-shirt" src="https://cdn.shopify.com/s/files/1/0101/8752/products/IMG_7672_1024x1024.jpg"></a>
 </p>
 
-<p align="center"><strong><a href="https://shop.planetargon.com/collections/everything/products/ohmyzsh-stickers-set-of-3-stickers">Get stickers!</a></strong></p>
+<p align="center"><strong><a href="https://shop.planetargon.com/collections/everything/products/ohmyzsh-logo-stickers">Get stickers!</a></strong></p>
 
 <p align="center"><a href="https://shop.planetargon.com/collections/everything/products/ohmyzsh-stickers-set-of-3-stickers"><img src="https://cdn.shopify.com/s/files/1/0101/8752/products/2013-09-25_11.35.14_medium.jpg" alt="Oh My Zsh stickers"></a></p>
 


### PR DESCRIPTION
Hi, just saw that the link to "Get stickers" is broken in sidebar. 