### PR TITLE
fix: remove zsh built-in from alias column

### DIFF
--- a/Cheatsheet.md
+++ b/Cheatsheet.md
@@ -27,7 +27,7 @@ Quick reference:
 | :--------- | :----------------------------------------- |
 | `md`       | `mkdir -p`                                 |
 | `rd`       | `rmdir`                                    |
-| `cd` / `~` | `cd` to your home directory                |
+| `~`        | `cd` (change to home directory)            |
 | `..`       | `cd ..`                                    |
 | `...`      | `cd ../..`                                 |
 | `....`     | `cd ../../..`                              |


### PR DESCRIPTION
Remove zsh built-in `cd` from Alias column
and move it to Command column instead,
following existing pattern for descriptions
used in table.

This fixes https://github.com/ohmyzsh/wiki/issues/50, which I opened in the other repo before I was aware of this separate repo for the wiki.