### PR TITLE
feat(External-plugins): add `tenv` plugin

### DIFF
--- a/External-plugins.md
+++ b/External-plugins.md
@@ -16,6 +16,10 @@ Unlike [themes](https://github.com/ohmyzsh/ohmyzsh/wiki/External-themes), there 
 
   [![fz demo](https://github.com/changyuheng/fz/raw/master/fz-demo.gif)](https://github.com/changyuheng/fz/blob/master/fz-demo.gif)
 
+- [tenv](https://github.com/tofuutils/zsh-tenv)
+
+  tofuutils tenv plugin providing autocompletions
+
 ### FUN
 
 - [Doge Say](https://github.com/txstc55/dogesay/blob/master/dogesay.plugin.zsh)


### PR DESCRIPTION
As suggested here: https://github.com/ohmyzsh/ohmyzsh/pull/12452

Add external plugin for tenv,
OpenTofu, Terraform, Terragrunt, and Atmos version manager, written in Go.


Please let me know if there's anything else I should do or change. 
Thank you.