### PR TITLE
feat(External-Themes): `guezwhoz` -> `ultima`

### DIFF
--- a/External-themes.md
+++ b/External-themes.md
@@ -270,16 +270,26 @@ author: [@masaakifuruki](https://github.com/masaakifuruki)
 
 ---
 
-#### guezwhoz
+#### Ultima Theme
 
-![guezwhoz](https://github.com/guesswhozzz/guezwhoz-scheme/blob/main/demos/completer-zsh-demo.gif?raw=true)
+![ultima theme](https://github.com/egorlem/021011/blob/main/demos/zsh-theme-demo-min.png?raw=true) 
 
-- Single git status marker for Visual Studio Code and Git cli
-- Interactive `Tab` completer
+**Minimalistic zsh theme designed to provide all the necessary settings for a comfortable terminal experience**
 
-source: [repo](https://github.com/guesswhozzz/guezwhoz-zshell)
+#### Features
+- **Multi-Line Prompt**: The prompt is divided into three lines for better readability. The first line separates the previous command's output from the prompt, the second line provides detailed path information, and the third line is for input.
+- **Multiple Prompt Levels**: Provides configurations for secondary and tertiary prompt levels (`PS2` and `PS3`).
+- **SSH Status Indicator**: Displays an indicator when an SSH connection is established.
+- **VCS (Version Control System) Integration**: Supports Git, SVN, and Mercurial for showing branch and repository status directly in the prompt.
+    - **Git Integration**: Shows branch name, staged and unstaged changes, and untracked files.
+    - **SVN and Mercurial Integration**: Shows branch name and repository status.
+- **Completion Enhancements**: Provides advanced completion settings, including menu completion, caching, and various completion styles and formats.
+- **LS_COLORS Configuration**: Configures `LS_COLORS` for both BSD and GNU systems to enhance the display of directory listings.
+- **LESS and MAN Configuration**: Customizes the behavior and appearance of `less` and `man` pages.
 
-author: [@guesswhozzz](https://github.com/guesswhozzz)
+See [repository](https://github.com/egorlem/ultima.zsh-theme) for source.
+
+author: [@egorlem](https://github.com/egorlem)
 
 ---
 

--- a/External-themes.md
+++ b/External-themes.md
@@ -272,7 +272,7 @@ author: [@masaakifuruki](https://github.com/masaakifuruki)
 
 #### Ultima Theme
 
-![ultima theme](https://github.com/egorlem/021011/blob/main/demos/zsh-theme-demo-min.png?raw=true) 
+![ultima theme](https://github.com/egorlem/ultima.workspace/blob/8b285369eab9ec1b49248f4c3f30a05676c36208/demos/zsh-theme-demo-min.png?raw=true) 
 
 **Minimalistic zsh theme designed to provide all the necessary settings for a comfortable terminal experience**
 


### PR DESCRIPTION
Hi theme 👋  

i'am author of guezwhoz theme (https://github.com/ohmyzsh/wiki/commit/ad3da31961a5074c7ec4ba9922fe5e1c283ecff7). Some time ago I changed my github username and changed the theme name. Would like to update them on the oh-my-zsh wiki. 

- Theme name has been changed
- More detailed description has been added
- Links to the repository and author have been corrected 

Best regards