### PR TITLE
Add databricks plugin to external plugins list

### DIFF
--- a/External-plugins.md
+++ b/External-plugins.md
@@ -27,6 +27,10 @@ Unlike [themes](https://github.com/ohmyzsh/ohmyzsh/wiki/External-themes), there 
 
   Integrate ChatGPT to your terminal so that you can predict your next command based on command history. Ask to generate complexe commands. Or Fix a previous failed command.
 
+- [Databricks CLI Plugin](https://github.com/SlavaYakovenko/zsh-databricks)
+  Enhanced Databricks CLI integration for Zsh with convenient aliases and profile management.
+  This plugin provides a set of convenient aliases and functions to streamline your Databricks workflow. All commands use the dbrs prefix to avoid conflicts with existing tools.
+
 - [Docker ps output colorized](https://github.com/bouteillerAlan/dockolor)
 
   `dockolor` is a lightweight plugin that enhances your docker ps experience with color-coded output based on container status. It also replaces common aliases like dps and dpsa if defined.


### PR DESCRIPTION
This PR adds the databricks plugin to the external plugins list.

## Plugin Overview
Enhanced Databricks CLI integration for Zsh with convenient aliases and profile management.

## Features
- Profile management with easy switching between environments (dev/staging/prod)
- Universal operations that work with current or specified profiles
- Job management and active runs monitoring
- Colored output for better readability
- Auto-completion for profile names
- All commands use `dbrs` prefix to avoid conflicts

## Installation
```bash
git clone https://github.com/SlavaYakovenko/zsh-databricks.git ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/databricks