### PR TITLE
feat(themes): add Hogwarts theme with detailed features and installation instructions

### DIFF
--- a/External-themes.md
+++ b/External-themes.md
@@ -1785,6 +1785,10 @@ The Hogwarts theme is a feature-rich Zsh prompt that displays comprehensive syst
 - **Command exit status indicator** with color-coded prompt character
 - **Real-time clock** showing current time
 
+## Source
+
+[Hogwarts theme](https://github.com/TheWinterShadow/HogwartsTrunk)
+
 ## Preview
 
 The prompt displays information in the following format:


### PR DESCRIPTION
This pull request adds documentation for the new "Hogwarts" Zsh theme to the `External-themes.md` file. The theme provides a visually rich and informative prompt, with features tailored for users who want enhanced git and system visibility, along with a Harry Potter-inspired color scheme.

New theme documentation:

* Added a comprehensive section for the "Hogwarts" Zsh theme, detailing its features, color usage, prompt layout, and preview image.
* Included installation instructions for both Oh My Zsh users and manual setup, making it easy for users to adopt the theme.

![](https://github.com/TheWinterShadow/HogwartsTrunk/blob/25ff1e2a552eda2a152a77d862426fad31967632/zsh/zsh_hogwarts_theme.png)
