### PR TITLE
feat(themes): add trios

### DIFF
--- a/External-themes.md
+++ b/External-themes.md
@@ -1816,3 +1816,27 @@ A Star Trek: The Next Generation LCARS-inspired theme for Oh My Zsh with modern 
 - 🕐 **Clock display** - Shows current time in HH:MM:SS format
 - 🚨 **Red Alert Mode** - All segments turn red when a command fails
 - 🎨 **Authentic LCARS color palette** - Using the official colors from Star Trek: TNG
+### Trios
+
+**A minimal cyberpunk ZSH prompt for pentesters,cyber-experts and CTF players.**
+
+![trios theme preview](https://raw.githubusercontent.com/MrEchoFi/trios-zsh-theme/main/preview.png)
+
+Features:
+- ⬡ Hexagon bullet segments
+- Electric blue path and prompt
+- Colour-coded command echo — blue for success, red for error
+- No Nerd Font required
+
+Install:
+
+```zsh
+git clone https://github.com/MrEchoFi/trios-zsh-theme.git \
+  ~/.oh-my-zsh/custom/themes/trios && \
+  cp ~/.oh-my-zsh/custom/themes/trios/trios.zsh-theme \
+  ~/.oh-my-zsh/custom/themes/
+```
+
+Then set `ZSH_THEME="trios"` in `~/.zshrc`
+
+- [Repository](https://github.com/MrEchoFi/trios-zsh-theme)


### PR DESCRIPTION
## New External Theme — trios

Hi, I'd like to add my ZSH theme **trios** to the External Themes list.

**Repo:** https://github.com/MrEchoFi/trios-zsh-theme

**Features:**
- Minimal cyberpunk prompt designed for pentesters and CTF players
- Hexagon bullet segments with electric blue highlights
- Colour-coded command echo (blue = success, red = error)
- No Nerd Font required — uses standard Unicode ⬡
- Tested on Ubuntu, Kali Linux and Parrot OS
- MIT License

Preview screenshot is included in the repo.