### PR TITLE
feat(plugins): add ccline

### DIFF
--- a/External-plugins.md
+++ b/External-plugins.md
@@ -13,6 +13,12 @@ Unlike [themes](https://github.com/ohmyzsh/ohmyzsh/wiki/External-themes), there 
 
 ### CLI
 
+- [ccline](https://github.com/jianshuo/ccline)
+
+  Type a natural-language thought directly at your zsh prompt — no command, no prefix. ccline intercepts `command_not_found_handler` and sends your query to Claude or Codex. If the AI response contains runnable commands, an interactive arrow-key menu lets you confirm and execute them in your live shell (so `cd`, `export`, etc. persist).
+
+  [![ccline demo](https://raw.githubusercontent.com/jianshuo/ccline/main/docs/demo.gif)](https://github.com/jianshuo/ccline)
+
 - [arc-zsh-plugin](https://github.com/dkryaklin/arc-zsh-plugin)
 
   Arc VCS prompt integration, status caching, and aliases. Supports agnoster theme with auto-injection.


### PR DESCRIPTION
## What does this add?

[ccline](https://github.com/jianshuo/ccline) — a zsh plugin that hijacks `command_not_found_handler`. When you type a natural-language thought at your prompt (two or more words that aren't a real command), it sends the query to Claude or Codex, renders the answer as Markdown, and shows an interactive arrow-key menu to confirm and run any suggested commands in your live shell.

**Key behaviors:**
- One word (typo like `gti`) → passes through normally, no API call
- Two+ words → treated as a question, sent to AI
- Selected commands run in the **live** shell — so `cd`, `export`, aliases all persist

**Install:**
```sh
curl -fsSL https://raw.githubusercontent.com/jianshuo/ccline/v0.2.2/install.sh | bash
```

Requires: zsh + `claude` CLI (preferred) or `codex` CLI — auto-detected.

Added to the **CLI** section as it's a general-purpose shell enhancement.