### PR TITLE
Add better-chmod to External plugins

### DIFF
--- a/External-plugins.md
+++ b/External-plugins.md
@@ -23,6 +23,10 @@ Unlike [themes](https://github.com/ohmyzsh/ohmyzsh/wiki/External-themes), there 
 
   Arc VCS prompt integration, status caching, and aliases. Supports agnoster theme with auto-injection.
 
+- [better-chmod](https://github.com/Balzabu/zsh-better-chmod)
+
+  Adds a `bchmod` command (and an optional `chmod` replacement) that accepts symbolic and octal permission formats with input validation and colored output.
+
 - [fz](https://github.com/changyuheng/fz)
 
   Give tab-completions to `z`.


### PR DESCRIPTION
Adds [better-chmod](https://github.com/Balzabu/zsh-better-chmod) to the CLI section of the External plugins page.

better-chmod adds a `bchmod` command (and an optional `chmod` replacement) that accepts symbolic and octal permission formats with input validation and colored output.

The README includes Oh My Zsh installation instructions following the [customization guidelines](https://github.com/ohmyzsh/ohmyzsh/wiki/Customization#overriding-and-adding-plugins), and the plugin is already listed in [awesome-zsh-plugins](https://github.com/unixorn/awesome-zsh-plugins).