### PR TITLE
feat(plugins): add git-commit-prefixer

### DIFF
--- a/External-plugins.md
+++ b/External-plugins.md
@@ -84,17 +84,21 @@ Unlike [themes](https://github.com/ohmyzsh/ohmyzsh/wiki/External-themes), there 
   user123/repo-9876/fix-bug-in-feature  -->  9876/fix...-feature
   ```
 
+- [Custom Git](https://github.com/davidde/git)
+
+  A small, tidy, lightweight notes app that creates a daily text file and timestamps every line of added text
+
 - [git-clean-branches](https://github.com/adelbeke/git-clean-branches)
 
   Interactive git branch deletion tool with a beautiful UI powered by [gum](https://github.com/charmbracelet/gum). Shows branch info with last commit date and message. Automatically protects current branch and main/master branches.
 
+- [git-commit-prefixer](https://github.com/dvigo/git-commit-prefixer)
+
+  A Zsh plugin that automatically prefixes your Git commit messages with Jira issue keys, project prefixes, or branch names.
+
 - [git-switch-branch](https://github.com/adelbeke/git-switch-branch)
 
   Interactive git branch switching tool with gum-powered UI. Displays branch info with last commit date and message. Warns about uncommitted changes with optional auto-stash.
-
-- [Custom Git](https://github.com/davidde/git)
-
-  A small, tidy, lightweight notes app that creates a daily text file and timestamps every line of added text
 
 - [Mingit](https://github.com/evansendra/mingit/tree/master/mingit-ohmyzsh)
 


### PR DESCRIPTION
This PR adds the [git-commit-prefixer](https://github.com/dvigo/git-commit-prefixer) Zsh plugin to the External-plugins list under the GIT category, sorted alphabetically.