### PR TITLE
External-plugins: add zsh-dual-history

### DIFF
--- a/External-plugins.md
+++ b/External-plugins.md
@@ -60,6 +60,10 @@ Unlike [themes](https://github.com/ohmyzsh/ohmyzsh/wiki/External-themes), there 
 
   A minimal Zsh plugin to quickly navigate into development folders with recursive autocompletion, create new project directories, and open them in your preferred editor (VS Code, Cursor, Windsurf, etc.) with fuzzy finder (`fzf`) integration.
 
+- [zsh-dual-history](https://github.com/odurif0/zsh-dual-history)
+
+  Keeps AI agent instructions out of your shell history. CLI agents like Forge send `:`-prefixed instructions that pollute `history` and `Ctrl+R`; this plugin routes them to a separate `~/.zsh_ai_history` — intercepting every write path, including the agent's own history insertions — and turns `Ctrl+R` into an fzf interface switchable between All / Human / AI views (`Tab`, `Alt+H/I/A`), merged chronologically.
+
 - [project-aliases](https://github.com/dvigo/project-aliases)
 
   Lightweight plugin to manage per-project shell aliases. It automatically loads aliases defined in a `.proj_aliases` file when entering a project directory and unloads them upon leaving, keeping your global shell namespace clean.


### PR DESCRIPTION
Adds [zsh-dual-history](https://github.com/odurif0/zsh-dual-history) to the CLI section (alphabetical order).

## What it does

CLI coding agents (e.g. Forge) inject `:`-prefixed instructions into the zsh prompt. Those land in the main shell history and pollute `history`, `!!`, and `Ctrl+R`. The plugin:

- Routes `:` commands to a separate `~/.zsh_ai_history` (EXTENDED_HISTORY format, multi-line safe), intercepting **every** write path — `preexec`, `zshaddhistory`, and the agent's own `print -s` insertions that bypass both hooks
- Replaces `Ctrl+R` with an fzf interface switchable between **All / Human / AI** views (`Tab` cycle, `Alt+H/I/A` jumps), both histories merged chronologically with duplicates collapsed
- Current-session commands stay visible (snapshot via `fc -A`), `FZF_CTRL_R_OPTS` honored
- Ships `scripts/migrate-pollution.sh` to move already-leaked instructions out of `~/.zsh_history`

Core layer works without any dependency (plain zsh ≥ 5.0); the fzf widget needs fzf 0.52+. MIT licensed.